### PR TITLE
incompatible change: parameters in search_by_sql is changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Select from specified table. Then, returns first of matched rows.
 
 ## search\_by\_sql
 
-    my @rows = $db->search_by_sql($sql, @bind_vals);
+    my @rows = $db->search_by_sql($sql, \@bind_vals [, $table_name]);
 
-Select by specified SQL. Then, returns matched rows as array.
+Select by specified SQL. Then, returns matched rows as array. $table\_name is optional and used for inflate parameter.
 
 ## update
 

--- a/lib/Otogiri.pm
+++ b/lib/Otogiri.pm
@@ -46,13 +46,14 @@ sub select {
     my ($self, $table, $param, @opts) = @_;
     $param = $self->_deflate_param($table, $param);
     my ($sql, @binds) = $self->maker->select($table, ['*'], $param, @opts);
-    $self->search_by_sql($sql, @binds);
+    $self->search_by_sql($sql, \@binds, $table);
 }
 
 sub search_by_sql {
-    my ($self, $sql, @binds) = @_;
+    my ($self, $sql, $binds_aref, $table) = @_;
+    my @binds = @{$binds_aref};
     my $rtn = $self->dbh->select_all($sql, @binds);
-    my @rows = $rtn ? $self->_inflate_rows(undef, @$rtn) : ();
+    my @rows = $rtn ? $self->_inflate_rows($table, @$rtn) : ();
 }
 
 sub single {
@@ -223,9 +224,9 @@ Select from specified table. Then, returns first of matched rows.
 
 =head2 search_by_sql
 
-    my @rows = $db->search_by_sql($sql, @bind_vals);
+    my @rows = $db->search_by_sql($sql, \@bind_vals [, $table_name]);
 
-Select by specified SQL. Then, returns matched rows as array.
+Select by specified SQL. Then, returns matched rows as array. $table_name is optional and used for inflate parameter.
 
 =head2 update
 

--- a/t/11_CLUD.t
+++ b/t/11_CLUD.t
@@ -69,11 +69,12 @@ subtest rollback => sub {
 
 subtest fast_insert_and_search_by_sql => sub {
     $db->fast_insert(member => {name => 'airwife', sex => 'female', created_at => time});
-    my @rows = $db->search_by_sql('SELECT * FROM member WHERE sex=? ORDER BY id', 'male');
+    my @rows = $db->search_by_sql('SELECT * FROM member WHERE sex=? ORDER BY id', ['male']);
     is scalar(@rows), 2;
     is $rows[0]->{name}, 'ytnobody';
     is $rows[0]->{sex}, 'male';
-    @rows = $db->search_by_sql('SELECT * FROM member WHERE sex=?', 'female');
+
+    @rows = $db->search_by_sql('SELECT * FROM member WHERE sex=?', ['female']);
     is scalar(@rows), 1;
     is $rows[0]->{name}, 'airwife';
     is $rows[0]->{sex}, 'female';


### PR DESCRIPTION
search_by_sql($sql, @binds) -> search_by_sql($sql, $binds_aref, $table)

In previous release, when select/search_by_sql calls inflate method, $table(table name) is not passed to inflate method. This change enables to pass $table to inflate method.
