### PR TITLE
insert/fast_insert returns last_insert_id

### DIFF
--- a/lib/DBIx/Otogiri.pm
+++ b/lib/DBIx/Otogiri.pm
@@ -80,6 +80,11 @@ sub fast_insert {
     $param = $self->_deflate_param($table, $param);
     my ($sql, @binds) = $self->maker->insert($table, $param, @opts);
     $self->dbh->query($sql, @binds);
+
+    if ( defined wantarray() ) {
+        return $self->last_insert_id;
+    }
+    return;
 }
 
 *insert = *fast_insert;
@@ -265,7 +270,7 @@ Please see ATTRIBUTE section.
 
 =head2 insert / fast_insert
 
-    my $is_success = $db->insert($table_name => $columns_in_hashref);
+    my $last_insert_id = $db->insert($table_name => $columns_in_hashref);
 
 Insert a data simply.
 

--- a/t/16_insert_with_last_insert_id.t
+++ b/t/16_insert_with_last_insert_id.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test::More;
+use Mock::Quick;
+use Otogiri;
+
+
+my $dbfile  = ':memory:';
+
+my $db = Otogiri->new( connect_info => ["dbi:SQLite:dbname=$dbfile", '', ''] );
+
+my $sql = "
+CREATE TABLE person (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT    NOT NULL,
+  age  INTEGER NOT NULL DEFAULT 20
+);";
+
+$db->do($sql);
+
+subtest 'insert with id', sub {
+    my $last_insert_id = $db->insert('person', {
+        name => 'Sherlock Shellingford',
+        age  => 15,
+    });
+    is $last_insert_id, $db->last_insert_id,
+};
+
+subtest 'fast_insert with id', sub {
+    my $last_insert_id = $db->insert('person', {
+        name => 'Nero Yuzurizaki',
+        age  => 15,
+    });
+    is $last_insert_id, $db->last_insert_id,
+};
+
+subtest 'last_insert_id is not called when void context', sub {
+    my $last_insert_id_is_called = 0;
+
+    my $guard = qclass(
+        -takeover => 'DBIx::Sunny::db',
+        last_insert_id => sub { $last_insert_id_is_called = 1 },
+    );
+
+    $db->insert('person', {
+        name => 'Hercule Barton',
+        age  => 16,
+    });
+
+    is $last_insert_id_is_called, 0;
+};
+
+
+done_testing;


### PR DESCRIPTION
insert() and fast_insert() returns last_insert_id() for convenience. 

This change is incompatible but I think previous return value(is_success: whether query is success or not) is rarely used.