### PR TITLE
no ping before fetch mysql_insertid

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,4 +16,5 @@ on 'test' => sub {
 
 on 'develop' => sub {
     requires 'Test::PostgreSQL';
+    requires 'Test::mysqld';
 };

--- a/lib/DBIx/Otogiri.pm
+++ b/lib/DBIx/Otogiri.pm
@@ -119,7 +119,7 @@ sub last_insert_id {
         my @rows = $self->search_by_sql('SELECT LASTVAL() AS lastval');
         return $rows[0]->{lastval};
     }
-    return $self->dbh->last_insert_id($catalog, $schema, $table, $field, $attr_href);
+    return $self->{dbh}->last_insert_id($catalog, $schema, $table, $field, $attr_href);
 }
 
 sub reconnect {

--- a/t/17_last_insert_id_in_mysql.t
+++ b/t/17_last_insert_id_in_mysql.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+use Otogiri;
+
+use Test::Requires 'Test::mysqld';
+
+my $mysql = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    }
+) or plan skip_all => $Test::mysqld::errstr;
+
+
+my $db = Otogiri->new( connect_info => [$mysql->dsn(dbname => 'test'), '', '', { RaiseError => 1, PrintError => 0 }] );
+
+my $sql_person = <<'EOF';
+CREATE TABLE person (
+    id   INTEGER       PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(48) NOT NULL,
+    age  INTEGER
+);
+EOF
+
+$db->dbh->do($sql_person);
+
+subtest 'last_insert_id with sequence name', sub {
+    $db->fast_insert('person', {
+        name => 'Sherlock Shellingford',
+        age  => 15,
+    });
+    $db->fast_insert('person', {
+        name => 'Nero Yuzurizaki',
+        age  => 15,
+    });
+
+    my ($row) = $db->search_by_sql('SELECT MAX(id) AS max_id FROM person');
+    my $lastval = $row->{max_id};
+
+    is( $db->last_insert_id, $lastval);
+};
+
+done_testing;


### PR DESCRIPTION
https://github.com/CaptTofu/DBD-mysql/issues/59

mysql_insertid is cleared after ping() is called. so this fix avoid to call ping before last_insert_id(fetching mysql_insertid)