### PR TITLE
Bump-up perl versions on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: perl
 perl:
-  - "5.18"
-  - "5.20"
   - "5.22"
   - "5.24"
+  - "5.26"
+  - "5.28"
+  - "5.30"
 
 before_script:
   - cpanm --quiet --notest --skip-satisfied Devel::Cover::Report::Coveralls


### PR DESCRIPTION
Perl-5.18 and 5.20 on Travis-ci looks failure to install some modules and alerted following issue.

https://travis-ci.org/ytnobody/Otogiri/jobs/637975702

```
!
! Can't write to /usr/local/share/perl/5.22.1 and /usr/local/bin: Installing modules to /home/travis/perl5
! To turn off this warning, you have to do one of the following:
!   - run me as a root or with --sudo option (to install to /usr/local/share/perl/5.22.1 and /usr/local/bin)
!   - Configure local::lib in your existing shell to set PERL_MM_OPT etc.
!   - Install local::lib by running the following commands
!
!         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
!
```

From this fact, I think it requires upgrade their perl versions that uses on travis-ci.

Any discussions? @tsucchi 

Best regards.